### PR TITLE
Remove C++ 11 requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: NetworkInference
 Type: Package
 Title: Inferring Latent Diffusion Networks
-Version: 1.2.4.9000
-Date: 2019-02-27
+Version: 1.2.3
+Date: 2025-11-28
 Authors@R: c(person("Fridolin", "Linder", email = "fridolin.linder@gmail.com",
                   role = c("aut", "cre")),
              person("Bruce", "Desmarais", role = "ctb"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,5 @@ Suggests:
     utils,
     dplyr
 RoxygenNote: 6.1.1
-SystemRequirements: C++11
 LazyData: true
 VignetteBuilder: knitr

--- a/man/policies.Rd
+++ b/man/policies.Rd
@@ -28,7 +28,7 @@ of the policies. It contains these columns:
 Both \code{data.frame} objects can be joined (merged) on the common column
 \code{policy} (see example code).}
 \source{
-\url{https://doi.org/10.7910/DVN/CVYSR7}
+\doi{10.7910/DVN/CVYSR7}
 }
 \usage{
 data(policies)


### PR DESCRIPTION
R now has default C++17, so no replacement required